### PR TITLE
Adding scope for function arguments

### DIFF
--- a/autoload/testify/assert.vim
+++ b/autoload/testify/assert.vim
@@ -6,7 +6,7 @@ function! s:assert(cond, ...) abort
 endfunction
 
 function! testify#assert#assert(cond)
-  call s:assert(cond)
+  call s:assert(a:cond)
 endfunction
 
 function! testify#assert#equals(actual, expected)
@@ -30,12 +30,12 @@ function! testify#assert#not_matches(actual, regexp)
 endfunction
 
 function! testify#assert#empty(actual)
-  let cond = empty(actual)
+  let cond = empty(a:actual)
   call s:assert(cond, 'Expected ' . a:actual . ' to be empty')
 endfunction
 
 function! testify#assert#not_empty(actual)
-  let cond = !empty(actual)
+  let cond = !empty(a:actual)
   call s:assert(cond, 'Expected ' . a:actual . ' to not be empty')
 endfunction
 


### PR DESCRIPTION
When attempting to call some functions asserting values i was running into an error with the variables. Using the following test.vim i was able to verify these changes are producing valid unit tests.

```
function! AddOne(l)
    return a:l + 1
endfunction

function! s:TestItAddsOne()
  let p = AddOne(1)
  call testify#assert#equals(p, 2)
endfunction
call testify#it('It Adds One', function('s:TestItAddsOne'))

function! s:TestItTestsAssert()
  let new_list = [1,2,3,4]
  let expected = [1,2,3,4]
  call testify#assert#assert(new_list == expected)
endfunction
call testify#it('It properly tests assert', function('s:TestItTestsAssert'))

function! s:TestItAssertsEmpty()
  let expected = ""
  call testify#assert#empty(expected)
endfunction
call testify#it('It is an empty string', function('s:TestItAssertsEmpty'))

function! s:TestItAssertsNotEmpty()
  let expected = "asdf"
  call testify#assert#not_empty(expected)
endfunction
call testify#it('It is an non_empty string', function('s:TestItAssertsNotEmpty'))

```